### PR TITLE
Add optind method

### DIFF
--- a/src/getopts.c
+++ b/src/getopts.c
@@ -138,12 +138,19 @@ mrb_getopt_long(mrb_state *mrb, mrb_value ary)
   return opt_hash;
 }
 
+static mrb_value 
+mrb_optind(mrb_state *mrb, mrb_value ary)
+{
+    return mrb_fixnum_value(optind);
+}
+
 void
 mrb_mruby_getopts_gem_init(mrb_state *mrb)
 {
   struct RClass *a = mrb_define_module(mrb, "Getopts");
 
   mrb_define_method(mrb, a, "getopt_long", mrb_getopt_long, MRB_ARGS_REQ(2));
+  mrb_define_method(mrb, a, "optind", mrb_optind, MRB_ARGS_NONE());
 }
 
 void

--- a/test/getopts.rb
+++ b/test/getopts.rb
@@ -67,4 +67,5 @@ assert "Array#getopts" do
   opt = ary.getopts('c:d', "verbose", "add:", "hoge:piyo")
   assert_equal %w(verbose c add hoge), opt.keys
   assert_equal ["", "foo", "bar", "piyo"], opt.values
+  assert_equal 5, ary.optind
 end


### PR DESCRIPTION
`optind` represents the first index after processing getopt_long. This allows subsequent arguments to be processed.